### PR TITLE
[쿠킴 / 땃쥐] 로또 3단계 - 수동구매 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ public class InputView {
     public static WinningTicket inputWinningTicket() {
         Set<LottoNumber> lottoNumbers = inputWinnnigNumbers();
         LottoNumber bonusNumber = inputBonusNumber();
-    
+
         return new WinningTicket(lottoNumbers, bonusNumber);
     }
     //(... 생략)
@@ -128,7 +128,7 @@ public enum Rank {
     FOURTH(4, 50_000L),
     FIFTH(3, 5_000L),
     FAILED(-1, 0L);
-    
+
     public static Rank of(int matchCount, boolean matchBonus) {
         switch (matchCount) {
             case 6:
@@ -153,14 +153,14 @@ public enum Rank {
         }
         return String.format("%d개 일치, (%d원)", countOfMatch, reward);
     }
-}
+    }
 ```
 
 - Rank의 상태 정보를 OutputView에서 접근하려니 Rank의 여러 getter를 통해 사용하는 불편함이 있었다.
 - 이를 위해 toString()을 오버라이딩 하여 해당 내용을 사용하였다.
 
 
-#### LottoGameResults 
+#### LottoGameResults
 
 ```java
 public class LottoGameResults {
@@ -189,6 +189,159 @@ public class LottoGameResults {
 - 깔끔해 보이지만 entry.getKey().getReward()나 entry.getValue()에 대한 의미를 파악하기 어려웠다.
 - 따라서 for문으로 변경하여 해당 변수명을 할당하여 의미 전달을 높였다.
 - 두 사이에 어떤것이 더 좋은지는 ... 잘 모르겠다.
+
+</div>
+</details>
+
+
+# step 3 : 수동구매 기능 추가
+
+- [x] 사용자 입력을 통해 수동 추첨번호를 입력할 수 있도록 기능 추가
+    - detail : 구입금액, 수동으로 생성하는 티켓 수, 수동 티켓들에 대한 입력 기능 요구
+- [x] 예외가 발생하는 부분에 대해 Exception을 발생시키고, 적절한 예외처리
+- [x] 상속과 인터페이스, 조합을 이용해 구현을 간결화하기
+
+<details>
+<summary> 🖼📝 Step 3 결과와 설명 </summary>
+<div markdown="1">
+
+### 결과
+
+<details>
+<summary> 🖼️ 결과 : 정상 입력 </summary>
+<div markdown="1">
+
+![정상 입력](https://i.imgur.com/2PCnFUV.jpg)
+
+</div>
+</details>
+
+<details>
+<summary> 🖼️ 결과 : 예외 입력 </summary>
+<div markdown="1">
+
+![예외 입력 시 재입력](https://i.imgur.com/iwNjJid.jpg)
+
+</div>
+</details>
+
+<details>
+<summary> 🖼️ 결과 :  테스트 </summary>
+<div markdown="1">
+
+![테스트1](https://i.imgur.com/XFEm0X2.jpg)
+
+![테스트2](https://i.imgur.com/sXjGiih.jpg)
+</div>
+</details>
+
+### 기능 추가 및 리팩토링
+
+#### LottoController
+```java
+public class LottoController {
+
+    public void run() {
+        LottoTickets lottoTickets = buyLottoTickets();
+        WinningTicket winningTicket = prepareWinningTicket();
+        matchLottoTicketsWithWinningTicket(lottoTickets, winningTicket);
+        closeController();
+    }
+    // ... (후술)
+}
+```
+- 기존 run 메서드 길이가 길어져 있던 것을 4개 계층으로 추상화하여 메서드 분리
+    1. `buyLottoTickets()` : 입력을 통해 로또티켓들 구입
+    2. `prepareWinningTicket()` : 입력을 통해 당첨티켓 준비
+    3. `matchLottoTicketsWithWinningTicket(...)` : 구입 로또티켓들과 당첨 로또티켓을 비교하여 추첨결과를 출력
+    4. `closeController()` : 프로그램 종료를 이전에, 모든 자원을 반환함.
+- 입력 예외 처리는 각 계층단위로 하도록 함. (예외 발생시 재귀호출하여, 다시 입력하도록 함.)
+
+
+#### LottoGameResults
+```java
+//이전 코드
+public class LottoGameResults {
+
+  private final Money money;
+  private final LottoTickets lottoTickets;
+  private final WinningTicket winningTicket;
+  private final Map<Rank, Integer> rankCounts;
+
+  public LottoGameResults(Money money, LottoTickets lottoTickets, WinningTicket winningTicket) {
+    this.money = money;
+    this.lottoTickets = lottoTickets;
+    this.winningTicket = winningTicket;
+    this.rankCounts = setupRankCounts();
+  }
+  // (... 생략...)
+}
+
+
+// 변경 코드
+public class LottoGameResults {
+
+  private final Map<Rank, Integer> rankCounts;
+  private final double returnToInvestment;
+
+  public LottoGameResults(LottoTickets lottoTickets, WinningTicket winningTicket) {
+    this.rankCounts = setupRankCounts(lottoTickets, winningTicket);
+    this.returnToInvestment = calculateReturnToInvestment(lottoTickets);
+  }
+  
+  // ... 세부 로직은 생략
+  
+}
+```
+- 기존 코드에서는 LottoGameResults를 계산하기 위해, 인자를 상태로 가지고 있었음.
+- 결과에 해당하는 객체인데 인자를 상태로 갖고 있는 것은 부자연스럽다는 것을 토론하면서 결론내렸음
+- LottoTickets, WinningTicket는 결과를 계산하기 위한 용도로만 사용함.
+- 결과를 계산하여 상수로 캐싱하고, 다른 객체가 요청할 때 캐싱된 결과값을 반환할 수 있도록 함
+  - (기존에는 이 부분을 호출시 계산해서 넘겨야했으나, 생성 시점에 전부 계산, 캐싱해두고 반환만 하게 함.)
+
+#### WinningTicket
+```java
+public class WinningTicket {
+
+    private final LottoTicket winningLottoTicket;
+    private final LottoNumber bonusNumber;
+
+    public WinningTicket(LottoTicket winningLottoTicket, LottoNumber bonusNumber) {
+        validateDuplicateLottoNumber(winningLottoTicket, bonusNumber);
+        this.winningLottoTicket = winningLottoTicket;
+        this.bonusNumber = bonusNumber;
+    }
+    //.. 생략
+}
+```
+- 기존엔 내부적으로 `Set<LottoNumber>`을 가지고 있었음.
+- 하지만 인자로 6개가 아닌 로또티켓번호들이 입력됐을 때에 대한 유효성 검사가 이루어지지 않은채 들어오게 되어, 데이터 무결성을 관리하기 힘듬.
+- WinningTicket이 6개의 로또번호를 가지고 있는 점은 LottoTicket과 공통점이 매우 많음.
+- 또한 6개의 번호가 들어오는 지에 대한 유효성 검사는 LottoTicket에서 충분히 수행하고 있음.
+- winningLottoTicket을 내부적으로 조합/구성(Composition)함으로서 추가적인 유효성 검사 코드를 작성하지 않아도 됨.
+
+#### LottoTicket, LottoTickets
+```java
+public class LottoTicket {
+    
+    //생략 ...
+  
+    /**
+     * 로또 티켓의 문자열 표현을 반환한다.
+     * 각 번호는 중복되지 않은 로또 번호이다.
+     * @return [x, x, x, x, x, x] 형태
+     */
+    @Override
+    public String toString() {
+        return lottoNumbers.stream().mapToInt(LottoNumber::getNumber)
+                .mapToObj(String::valueOf)
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+    //...생략
+}
+```
+- LottoTicket, LottoTickets에 toString 메서드를 통해 속해있는 로또티켓 번호들을 문자열로 반환하도록 함.
+
 
 </div>
 </details>

--- a/src/main/java/controller/LottoController.java
+++ b/src/main/java/controller/LottoController.java
@@ -8,13 +8,10 @@ public class LottoController {
 
     public void run() {
         LottoTickets lottoTickets = buyLottoTickets();
-
-        WinningTicket winningTicket = InputView.inputWinningTicket();
-        LottoGameResults lottoGameResults = new LottoGameResults(lottoTickets, winningTicket);
-        OutputView.printLottoGameResults(lottoGameResults);
-        InputView.close();
+        WinningTicket winningTicket = prepareWinningTicket();
+        matchLottoTicketsWithWinningTicket(lottoTickets, winningTicket);
+        closeController();
     }
-
 
     private LottoTickets buyLottoTickets() {
         Money money = InputView.inputMoney();
@@ -26,5 +23,18 @@ public class LottoController {
         OutputView.printLottoTicketCounts(manualLottoTickets, randomLottoTickets);
         OutputView.printLottoTickets(allLottoTickets);
         return allLottoTickets;
+    }
+
+    private WinningTicket prepareWinningTicket() {
+        return InputView.inputWinningTicket();
+    }
+
+    private void matchLottoTicketsWithWinningTicket(LottoTickets lottoTickets, WinningTicket winningTicket) {
+        LottoGameResults lottoGameResults = new LottoGameResults(lottoTickets, winningTicket);
+        OutputView.printLottoGameResults(lottoGameResults);
+    }
+
+    private void closeController() {
+        InputView.close();
     }
 }

--- a/src/main/java/controller/LottoController.java
+++ b/src/main/java/controller/LottoController.java
@@ -14,15 +14,21 @@ public class LottoController {
     }
 
     private LottoTickets buyLottoTickets() {
-        Money money = InputView.inputMoney();
-        int count = InputView.inputCountOfManualLottoTicket(money);
-        LottoTickets manualLottoTickets = LottoTickets.createManualTickets((InputView.inputManualLottoTickets(count)));
-        LottoTickets randomLottoTickets = LottoTickets.createRandomTickets(money.numberOfBuyableLottoTickets() - count);
-        LottoTickets allLottoTickets = LottoTickets.merge(manualLottoTickets, randomLottoTickets);
+        try {
+            Money money = InputView.inputMoney();
+            int count = InputView.inputCountOfManualLottoTicket(money);
+            LottoTickets manualLottoTickets = LottoTickets.createManualTickets((InputView.inputManualLottoTickets(count)));
+            LottoTickets randomLottoTickets = LottoTickets.createRandomTickets(money.numberOfBuyableLottoTickets() - count);
+            LottoTickets allLottoTickets = LottoTickets.merge(manualLottoTickets, randomLottoTickets);
 
-        OutputView.printLottoTicketCounts(manualLottoTickets, randomLottoTickets);
-        OutputView.printLottoTickets(allLottoTickets);
-        return allLottoTickets;
+            OutputView.printLottoTicketCounts(manualLottoTickets, randomLottoTickets);
+            OutputView.printLottoTickets(allLottoTickets);
+            return allLottoTickets;
+        } catch (IllegalArgumentException e) {
+            System.out.println(e.getMessage());
+            System.out.println();
+        }
+        return buyLottoTickets();
     }
 
     private WinningTicket prepareWinningTicket() {

--- a/src/main/java/controller/LottoController.java
+++ b/src/main/java/controller/LottoController.java
@@ -8,7 +8,6 @@ public class LottoController {
 
     public void run() {
         LottoTickets lottoTickets = buyLottoTickets();
-        OutputView.printLottoTickets(lottoTickets);
 
         WinningTicket winningTicket = InputView.inputWinningTicket();
         LottoGameResults lottoGameResults = new LottoGameResults(lottoTickets, winningTicket);
@@ -22,7 +21,10 @@ public class LottoController {
         int count = InputView.inputCountOfManualLottoTicket(money);
         LottoTickets manualLottoTickets = LottoTickets.createManualTickets((InputView.inputManualLottoTickets(count)));
         LottoTickets randomLottoTickets = LottoTickets.createRandomTickets(money.numberOfBuyableLottoTickets() - count);
+        LottoTickets allLottoTickets = LottoTickets.merge(manualLottoTickets, randomLottoTickets);
 
-        return LottoTickets.merge(manualLottoTickets, randomLottoTickets);
+        OutputView.printLottoTicketCounts(manualLottoTickets, randomLottoTickets);
+        OutputView.printLottoTickets(allLottoTickets);
+        return allLottoTickets;
     }
 }

--- a/src/main/java/controller/LottoController.java
+++ b/src/main/java/controller/LottoController.java
@@ -7,15 +7,22 @@ import view.output.OutputView;
 public class LottoController {
 
     public void run() {
-        Money money = InputView.inputMoney();
-        LottoTickets lottoTickets = LottoTickets.createRandomTickets(money);
+        LottoTickets lottoTickets = buyLottoTickets();
         OutputView.printLottoTickets(lottoTickets);
 
         WinningTicket winningTicket = InputView.inputWinningTicket();
-        LottoGameResults lottoGameResults = new LottoGameResults(money, lottoTickets, winningTicket);
-
+        LottoGameResults lottoGameResults = new LottoGameResults(lottoTickets, winningTicket);
         OutputView.printLottoGameResults(lottoGameResults);
         InputView.close();
     }
 
+
+    private LottoTickets buyLottoTickets() {
+        Money money = InputView.inputMoney();
+        int count = InputView.inputCountOfManualLottoTicket(money);
+        LottoTickets manualLottoTickets = LottoTickets.createManualTickets((InputView.inputManualLottoTickets(count)));
+        LottoTickets randomLottoTickets = LottoTickets.createRandomTickets(money.numberOfBuyableLottoTickets() - count);
+
+        return LottoTickets.merge(manualLottoTickets, randomLottoTickets);
+    }
 }

--- a/src/main/java/controller/LottoController.java
+++ b/src/main/java/controller/LottoController.java
@@ -32,7 +32,13 @@ public class LottoController {
     }
 
     private WinningTicket prepareWinningTicket() {
-        return InputView.inputWinningTicket();
+        try {
+            return InputView.inputWinningTicket();
+        } catch (IllegalArgumentException e) {
+            System.out.println(e.getMessage());
+            System.out.println();
+        }
+        return prepareWinningTicket();
     }
 
     private void matchLottoTicketsWithWinningTicket(LottoTickets lottoTickets, WinningTicket winningTicket) {

--- a/src/main/java/controller/LottoController.java
+++ b/src/main/java/controller/LottoController.java
@@ -16,12 +16,13 @@ public class LottoController {
     private LottoTickets buyLottoTickets() {
         try {
             Money money = InputView.inputMoney();
-            int count = InputView.inputCountOfManualLottoTicket(money);
-            LottoTickets manualLottoTickets = LottoTickets.createManualTickets((InputView.inputManualLottoTickets(count)));
-            LottoTickets randomLottoTickets = LottoTickets.createRandomTickets(money.numberOfBuyableLottoTickets() - count);
+            long countOfManualLottoTicket = InputView.inputCountOfManualLottoTicket(money);
+            long countOfRandomlLottoTicket = money.numberOfBuyableLottoTickets() - countOfManualLottoTicket;
+            LottoTickets manualLottoTickets = LottoTickets.createManualTickets((InputView.inputManualLottoTickets(countOfManualLottoTicket)));
+            LottoTickets randomLottoTickets = LottoTickets.createRandomTickets(countOfRandomlLottoTicket);
             LottoTickets allLottoTickets = LottoTickets.merge(manualLottoTickets, randomLottoTickets);
 
-            OutputView.printLottoTicketCounts(manualLottoTickets, randomLottoTickets);
+            OutputView.printLottoTicketCounts(countOfManualLottoTicket, countOfRandomlLottoTicket);
             OutputView.printLottoTickets(allLottoTickets);
             return allLottoTickets;
         } catch (IllegalArgumentException e) {

--- a/src/main/java/domain/lotto/LottoGameResults.java
+++ b/src/main/java/domain/lotto/LottoGameResults.java
@@ -6,13 +6,11 @@ import java.util.Map;
 
 public class LottoGameResults {
 
-    private final Money money;
     private final LottoTickets lottoTickets;
     private final WinningTicket winningTicket;
     private final Map<Rank, Integer> rankCounts;
 
-    public LottoGameResults(Money money, LottoTickets lottoTickets, WinningTicket winningTicket) {
-        this.money = money;
+    public LottoGameResults(LottoTickets lottoTickets, WinningTicket winningTicket) {
         this.lottoTickets = lottoTickets;
         this.winningTicket = winningTicket;
         this.rankCounts = setupRankCounts();
@@ -42,8 +40,8 @@ public class LottoGameResults {
 
     public double getReturnToInvestment() {
         long totalRewards = getTotalRewards();
-        double profit = totalRewards - money.getPurchaseAmount();
-        double returnOfInvestment = (profit) / money.getPurchaseAmount() * 100;
+        double profit = totalRewards - lottoTickets.getPriceSum();
+        double returnOfInvestment = (profit) / lottoTickets.getPriceSum() * 100;
         return returnOfInvestment;
     }
 

--- a/src/main/java/domain/lotto/LottoGameResults.java
+++ b/src/main/java/domain/lotto/LottoGameResults.java
@@ -7,13 +7,12 @@ import java.util.stream.Stream;
 
 public class LottoGameResults {
 
-    private final double returnToInvestment;
-
     private final Map<Rank, Integer> rankCounts;
+    private final double returnToInvestment;
 
     public LottoGameResults(LottoTickets lottoTickets, WinningTicket winningTicket) {
         this.rankCounts = setupRankCounts(lottoTickets, winningTicket);
-        returnToInvestment = calculateReturnToInvestment(lottoTickets);
+        this.returnToInvestment = calculateReturnToInvestment(lottoTickets);
     }
 
     private Map<Rank, Integer> setupRankCounts(LottoTickets lottoTickets, WinningTicket winningTicket) {

--- a/src/main/java/domain/lotto/LottoGameResults.java
+++ b/src/main/java/domain/lotto/LottoGameResults.java
@@ -12,7 +12,6 @@ public class LottoGameResults {
     private final Map<Rank, Integer> rankCounts;
 
     public LottoGameResults(LottoTickets lottoTickets, WinningTicket winningTicket) {
-
         this.rankCounts = setupRankCounts(lottoTickets, winningTicket);
         returnToInvestment = calculateReturnToInvestment(lottoTickets);
     }

--- a/src/main/java/domain/lotto/LottoNumber.java
+++ b/src/main/java/domain/lotto/LottoNumber.java
@@ -29,8 +29,19 @@ public class LottoNumber {
     }
 
     public static LottoNumber of(int number) {
+        validateRangeOfNumber(number);
         return LOTTO_NUMBER_POOL.get(number);
     }
+
+    private static void validateRangeOfNumber(int number) {
+        if (MIN_RANDOM_NUMBER <= number && number <= MAX_RANDOM_NUMBER) {
+            return;
+        }
+        throw new IllegalArgumentException(String.format("로또 번호의 유효 범위는 %d ~ %d 입니다.",
+                MIN_RANDOM_NUMBER,
+                MAX_RANDOM_NUMBER));
+    }
+
 
     public static LottoNumber getLottoRandomLottoNumber() {
         int randomNumber = (int) (Math.random() * MAX_RANDOM_NUMBER) + MIN_RANDOM_NUMBER;

--- a/src/main/java/domain/lotto/LottoTicket.java
+++ b/src/main/java/domain/lotto/LottoTicket.java
@@ -24,6 +24,10 @@ public class LottoTicket {
         throw new IllegalArgumentException(String.format("서로 다른 로또 번호가 %d개 존재하지 않습니다.", LIMIT_LOTTO_NUMBERS));
     }
 
+    public static LottoTicket createManualTicket(Set<LottoNumber> lottoNumbers) {
+        return new LottoTicket(lottoNumbers);
+    }
+
     public static LottoTicket createRandomTicket() {
         Set<LottoNumber> lottoNumbers = new HashSet<>();
         while (lottoNumbers.size() != LIMIT_LOTTO_NUMBERS) {
@@ -33,8 +37,8 @@ public class LottoTicket {
         return new LottoTicket(lottoNumbers);
     }
 
-    public static LottoTicket createManualTicket(Set<LottoNumber> lottoNumbers) {
-        return new LottoTicket(lottoNumbers);
+    public boolean contains(LottoNumber bonusNumber) {
+        return lottoNumbers.contains(bonusNumber);
     }
 
     public Set<LottoNumber> getLottoNumbers() {
@@ -53,7 +57,4 @@ public class LottoTicket {
                 .collect(Collectors.joining(", ", "[", "]"));
     }
 
-    public boolean contains(LottoNumber bonusNumber) {
-        return lottoNumbers.contains(bonusNumber);
-    }
 }

--- a/src/main/java/domain/lotto/LottoTicket.java
+++ b/src/main/java/domain/lotto/LottoTicket.java
@@ -7,6 +7,7 @@ import java.util.Set;
 public class LottoTicket {
 
     private static final int LIMIT_LOTTO_NUMBERS = 6;
+    public static final int LOTTO_TICKET_PRICE = 1000;
 
     private final Set<LottoNumber> lottoNumbers;
 

--- a/src/main/java/domain/lotto/LottoTicket.java
+++ b/src/main/java/domain/lotto/LottoTicket.java
@@ -52,4 +52,8 @@ public class LottoTicket {
                 .mapToObj(String::valueOf)
                 .collect(Collectors.joining(", ", "[", "]"));
     }
+
+    public boolean contains(LottoNumber bonusNumber) {
+        return lottoNumbers.contains(bonusNumber);
+    }
 }

--- a/src/main/java/domain/lotto/LottoTicket.java
+++ b/src/main/java/domain/lotto/LottoTicket.java
@@ -3,6 +3,7 @@ package domain.lotto;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class LottoTicket {
 
@@ -38,5 +39,17 @@ public class LottoTicket {
 
     public Set<LottoNumber> getLottoNumbers() {
         return Collections.unmodifiableSet(lottoNumbers);
+    }
+
+    /**
+     * 로또 티켓의 문자열 표현을 반환한다.
+     * 각 번호는 중복되지 않은 로또 번호이다.
+     * @return [x, x, x, x, x, x] 형태
+     */
+    @Override
+    public String toString() {
+        return lottoNumbers.stream().mapToInt(LottoNumber::getNumber)
+                .mapToObj(String::valueOf)
+                .collect(Collectors.joining(", ", "[", "]"));
     }
 }

--- a/src/main/java/domain/lotto/LottoTicket.java
+++ b/src/main/java/domain/lotto/LottoTicket.java
@@ -11,7 +11,15 @@ public class LottoTicket {
     private final Set<LottoNumber> lottoNumbers;
 
     private LottoTicket(Set<LottoNumber> lottoNumbers) {
+        validateLottoNumbersSize(lottoNumbers);
         this.lottoNumbers = lottoNumbers;
+    }
+
+    private void validateLottoNumbersSize(Set<LottoNumber> lottoNumbers) {
+        if (lottoNumbers.size() == LIMIT_LOTTO_NUMBERS) {
+            return;
+        }
+        throw new IllegalArgumentException(String.format("서로 다른 로또 번호가 %d개 존재하지 않습니다.", LIMIT_LOTTO_NUMBERS));
     }
 
     public static LottoTicket createRandomTicket() {
@@ -20,6 +28,10 @@ public class LottoTicket {
             lottoNumbers.add(LottoNumber.getLottoRandomLottoNumber());
         }
 
+        return new LottoTicket(lottoNumbers);
+    }
+
+    public static LottoTicket createManualTicket(Set<LottoNumber> lottoNumbers) {
         return new LottoTicket(lottoNumbers);
     }
 

--- a/src/main/java/domain/lotto/LottoTickets.java
+++ b/src/main/java/domain/lotto/LottoTickets.java
@@ -6,21 +6,45 @@ import java.util.List;
 
 public class LottoTickets {
 
-    private final List<LottoTicket> lottoTickets = new ArrayList<>();
+    private final List<LottoTicket> lottoTickets;
 
-    private LottoTickets(Money money) {
-        long numberOfLottoTickets = money.numberOfBuyableLottoTickets();
+    private LottoTickets(long numberOfLottoTickets) {
+        lottoTickets = new ArrayList<>();
         for (long count = 0; count < numberOfLottoTickets; count++) {
             lottoTickets.add(LottoTicket.createRandomTicket());
         }
     }
 
-    public static LottoTickets createRandomTickets(Money money) {
-        return new LottoTickets(money);
+    private LottoTickets(List<LottoTicket> tickets) {
+        this.lottoTickets = tickets;
+    }
+
+    private LottoTickets(LottoTickets... allTickets) {
+        this.lottoTickets = new ArrayList<>();
+
+        for (LottoTickets tickets : allTickets) {
+            this.lottoTickets.addAll(tickets.lottoTickets);
+        }
+    }
+
+    public static LottoTickets createRandomTickets(long numberOfLottoTickets) {
+        return new LottoTickets(numberOfLottoTickets);
+    }
+
+
+    public static LottoTickets createManualTickets(List<LottoTicket> manualLottoTickets) {
+        return new LottoTickets(manualLottoTickets);
+    }
+
+    public static LottoTickets merge(LottoTickets manualLottoTickets, LottoTickets randomLottoTickets) {
+        return new LottoTickets(manualLottoTickets, randomLottoTickets);
     }
 
     public List<LottoTicket> getLottoTickets() {
         return Collections.unmodifiableList(lottoTickets);
     }
 
+    public double getPriceSum() {
+        return lottoTickets.size() * LottoTicket.LOTTO_TICKET_PRICE;
+    }
 }

--- a/src/main/java/domain/lotto/LottoTickets.java
+++ b/src/main/java/domain/lotto/LottoTickets.java
@@ -10,12 +10,18 @@ public class LottoTickets {
     private final List<LottoTicket> lottoTickets;
 
     private LottoTickets(long numberOfLottoTickets) {
+        validateNumberOfLottoTickets(numberOfLottoTickets);
         lottoTickets = new ArrayList<>();
         for (long count = 0; count < numberOfLottoTickets; count++) {
             lottoTickets.add(LottoTicket.createRandomTicket());
         }
     }
 
+    private void validateNumberOfLottoTickets(long numberOfLottoTickets) {
+        if (numberOfLottoTickets < 0) {
+            throw new IllegalArgumentException("음수의 랜덤한 로또 티켓을 생성할 수 없습니다.");
+        }
+    }
     private LottoTickets(List<LottoTicket> tickets) {
         this.lottoTickets = tickets;
     }
@@ -31,7 +37,6 @@ public class LottoTickets {
     public static LottoTickets createRandomTickets(long numberOfLottoTickets) {
         return new LottoTickets(numberOfLottoTickets);
     }
-
 
     public static LottoTickets createManualTickets(List<LottoTicket> manualLottoTickets) {
         return new LottoTickets(manualLottoTickets);

--- a/src/main/java/domain/lotto/LottoTickets.java
+++ b/src/main/java/domain/lotto/LottoTickets.java
@@ -45,6 +45,10 @@ public class LottoTickets {
     }
 
     public double getPriceSum() {
-        return lottoTickets.size() * LottoTicket.LOTTO_TICKET_PRICE;
+        return getCountOfLottoTickets() * LottoTicket.LOTTO_TICKET_PRICE;
+    }
+
+    public int getCountOfLottoTickets() {
+        return lottoTickets.size();
     }
 }

--- a/src/main/java/domain/lotto/LottoTickets.java
+++ b/src/main/java/domain/lotto/LottoTickets.java
@@ -3,6 +3,7 @@ package domain.lotto;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class LottoTickets {
 
@@ -50,5 +51,16 @@ public class LottoTickets {
 
     public int getCountOfLottoTickets() {
         return lottoTickets.size();
+    }
+
+    /**
+     * 로또 티켓들의 문자열 표현을 반환한다.
+     * @return lottoTickets가 2개라면 [x, x, x, x, x, x]\n[x, x, x, x, x, x] 형태
+     */
+    @Override
+    public String toString() {
+        return lottoTickets.stream()
+                .map(LottoTicket::toString)
+                .collect(Collectors.joining("\n"));
     }
 }

--- a/src/main/java/domain/lotto/Money.java
+++ b/src/main/java/domain/lotto/Money.java
@@ -2,8 +2,6 @@ package domain.lotto;
 
 public class Money {
 
-    private static final long PRICE_OF_LOTTO = 1000;
-
     private final long purchaseAmount;
 
     public Money(long purchaseAmount) {
@@ -20,7 +18,7 @@ public class Money {
         if (isMultipleOfPrice(purchaseAmount)) {
             return;
         }
-        throw new IllegalArgumentException(String.format("구입금액은 %d의 배수만 가능합니다.", PRICE_OF_LOTTO));
+        throw new IllegalArgumentException(String.format("구입금액은 %d의 배수만 가능합니다.", LottoTicket.LOTTO_TICKET_PRICE));
     }
 
     private boolean isMultipleOfPrice(long purchaseAmount) {
@@ -31,11 +29,11 @@ public class Money {
         if (isValidRangeOfPurchaseAmount(purchaseAmount)) {
             return;
         }
-        throw new IllegalArgumentException(String.format("구입금액은 %d 이상만 허용됩니다.", PRICE_OF_LOTTO));
+        throw new IllegalArgumentException(String.format("구입금액은 %d 이상만 허용됩니다.", LottoTicket.LOTTO_TICKET_PRICE));
     }
 
     private boolean isValidRangeOfPurchaseAmount(long purchaseAmount) {
-        return PRICE_OF_LOTTO <= purchaseAmount;
+        return LottoTicket.LOTTO_TICKET_PRICE <= purchaseAmount;
     }
 
     public long getPurchaseAmount() {
@@ -43,6 +41,6 @@ public class Money {
     }
 
     public long numberOfBuyableLottoTickets() {
-        return purchaseAmount / PRICE_OF_LOTTO;
+        return purchaseAmount / LottoTicket.LOTTO_TICKET_PRICE;
     }
 }

--- a/src/main/java/domain/lotto/Rank.java
+++ b/src/main/java/domain/lotto/Rank.java
@@ -6,13 +6,13 @@ public enum Rank {
     THIRD(5, 1_500_000L),
     FOURTH(4, 50_000L),
     FIFTH(3, 5_000L),
-    FAILED(-1, 0L);
+    FAILED(0, 0L);
 
     private final int countOfMatch;
     private final long reward;
 
-    Rank(int contOfMatch, long reward) {
-        this.countOfMatch = contOfMatch;
+    Rank(int countOfMatch, long reward) {
+        this.countOfMatch = countOfMatch;
         this.reward = reward;
     }
 

--- a/src/main/java/domain/lotto/WinningTicket.java
+++ b/src/main/java/domain/lotto/WinningTicket.java
@@ -26,7 +26,8 @@ public class WinningTicket {
     }
 
     private boolean isMatchBonus(LottoTicket lottoTicket) {
-        return winningNumbers.contains(bonusNumber);
+        Set<LottoNumber> lottoNumbers = lottoTicket.getLottoNumbers();
+        return lottoNumbers.contains(bonusNumber);
     }
 
     private int calculateMatchCount(LottoTicket lottoTicket) {

--- a/src/main/java/domain/lotto/WinningTicket.java
+++ b/src/main/java/domain/lotto/WinningTicket.java
@@ -4,17 +4,17 @@ import java.util.Set;
 
 public class WinningTicket {
 
-    private final Set<LottoNumber> winningNumbers;
+    private final LottoTicket winningLottoTicket;
     private final LottoNumber bonusNumber;
 
-    public WinningTicket(Set<LottoNumber> winningNumbers, LottoNumber bonusNumber) {
-        validateDuplicateLottoNumber(winningNumbers, bonusNumber);
-        this.winningNumbers = winningNumbers;
+    public WinningTicket(LottoTicket winningLottoTicket, LottoNumber bonusNumber) {
+        validateDuplicateLottoNumber(winningLottoTicket, bonusNumber);
+        this.winningLottoTicket = winningLottoTicket;
         this.bonusNumber = bonusNumber;
     }
 
-    private void validateDuplicateLottoNumber(Set<LottoNumber> winningNumbers, LottoNumber bonusNumber) {
-        if (winningNumbers.contains(bonusNumber)) {
+    private void validateDuplicateLottoNumber(LottoTicket winningLottoTicket, LottoNumber bonusNumber) {
+        if (winningLottoTicket.contains(bonusNumber)) {
             throw new IllegalArgumentException(String.format("보너스 번호 %d가 당첨번호와 중복됩니다.", bonusNumber.getNumber()));
         }
     }
@@ -32,7 +32,7 @@ public class WinningTicket {
 
     private int calculateMatchCount(LottoTicket lottoTicket) {
         return (int) lottoTicket.getLottoNumbers().stream()
-                .filter(winningNumbers::contains)
+                .filter(winningLottoTicket::contains)
                 .count();
     }
 }

--- a/src/main/java/view/input/InputView.java
+++ b/src/main/java/view/input/InputView.java
@@ -1,18 +1,16 @@
 package view.input;
 
-import domain.lotto.Money;
-import domain.lotto.LottoNumber;
-import domain.lotto.WinningTicket;
+import domain.lotto.*;
 
-import java.util.HashSet;
-import java.util.Scanner;
-import java.util.Set;
+import java.util.*;
 
 public class InputView {
 
     private static final String REQUEST_INPUT_MONEY_MESSAGE = "구매금액을 입력해주세요.\nMoney > ";
     private static final String REQUEST_INPUT_WINNING_NUMBERS_MESSAGE = "당첨 번호를 입력해주세요.\nWinning Numbers > ";
     private static final String REQUEST_INPUT_BONUS_NUMBER_MESSAGE = "보너스 볼을 입력해 주세요.\nBonue Number > ";
+    private static final String REQUEST_INPUT_MANUAL_LOTTOTICKET_NUMBER_MESSAGE = "수동으로 구매할 로또 수를 입력해 주세요.\n개수 > ";
+    private static final String REQUEST_INPUT_MANUAL_LOTTO_NUMBERS = "수동으로 구매할 번호를 입력해 주세요.\n";
     private static final Scanner scanner = new Scanner(System.in);
 
     public static void close() {
@@ -22,6 +20,7 @@ public class InputView {
     public static Money inputMoney() {
         System.out.print(REQUEST_INPUT_MONEY_MESSAGE);
         int inputMoney = Integer.parseInt(scanner.nextLine());
+        System.out.println();
         return new Money(inputMoney);
     }
 
@@ -32,10 +31,15 @@ public class InputView {
         return new WinningTicket(lottoNumbers, bonusNumber);
     }
 
-    private static Set<LottoNumber>  inputWinnnigNumbers() {
+    private static Set<LottoNumber> inputWinnnigNumbers() {
         System.out.print(REQUEST_INPUT_WINNING_NUMBERS_MESSAGE);
-        String[] inputSplit = scanner.nextLine().split(",");
+        Set<LottoNumber> winningNumbers = inputLottoNumbers();
         System.out.println();
+        return winningNumbers;
+    }
+
+    private static Set<LottoNumber> inputLottoNumbers() {
+        String[] inputSplit = scanner.nextLine().split(",");
         Set<LottoNumber> lottoNumbers = parseLottoNumbers(inputSplit);
         return lottoNumbers;
     }
@@ -55,5 +59,43 @@ public class InputView {
             lottoNumbers.add(lottoNumber);
         }
         return lottoNumbers;
+    }
+
+    public static int inputCountOfManualLottoTicket(Money money) {
+        System.out.print(REQUEST_INPUT_MANUAL_LOTTOTICKET_NUMBER_MESSAGE);
+        int inputCountOfManualLottoTicket = Integer.parseInt(scanner.nextLine());
+        validatePurchaseCount(inputCountOfManualLottoTicket, money);
+        System.out.println();
+        return inputCountOfManualLottoTicket;
+    }
+
+    private static void validatePurchaseCount(int countOfManualLottoTicket, Money money) {
+        long buyableLottoTicketCount = money.numberOfBuyableLottoTickets();
+        if (0 <= countOfManualLottoTicket  && countOfManualLottoTicket <= buyableLottoTicketCount) {
+            return;
+        }
+        throw new IllegalArgumentException("유효한 수동 구매 개수가 아닙니다.");
+    }
+
+    public static List<LottoTicket> inputManualLottoTickets(int count) {
+        return isManualTicketCountZero(count) ? new ArrayList<>() : createManualLottoTickets(count);
+    }
+
+    private static List<LottoTicket> createManualLottoTickets(int count) {
+        System.out.print(REQUEST_INPUT_MANUAL_LOTTO_NUMBERS);
+        List<LottoTicket> tickets = new ArrayList<>();
+        for (int i = 0; i< count; i++) {
+            tickets.add(LottoTicket.createManualTicket(inputManualTicket()));
+        }
+        System.out.println();
+        return tickets;
+    }
+
+    private static boolean isManualTicketCountZero(int count) {
+        return count == 0;
+    }
+
+    private static Set<LottoNumber> inputManualTicket() {
+        return inputLottoNumbers();
     }
 }

--- a/src/main/java/view/input/InputView.java
+++ b/src/main/java/view/input/InputView.java
@@ -62,15 +62,15 @@ public class InputView {
         return lottoNumbers;
     }
 
-    public static int inputCountOfManualLottoTicket(Money money) {
+    public static long inputCountOfManualLottoTicket(Money money) {
         System.out.print(REQUEST_INPUT_MANUAL_LOTTOTICKET_NUMBER_MESSAGE);
-        int inputCountOfManualLottoTicket = Integer.parseInt(scanner.nextLine());
+        long inputCountOfManualLottoTicket = Integer.parseInt(scanner.nextLine());
         validatePurchaseCount(inputCountOfManualLottoTicket, money);
         System.out.println();
         return inputCountOfManualLottoTicket;
     }
 
-    private static void validatePurchaseCount(int countOfManualLottoTicket, Money money) {
+    private static void validatePurchaseCount(long countOfManualLottoTicket, Money money) {
         long buyableLottoTicketCount = money.numberOfBuyableLottoTickets();
         if (0 <= countOfManualLottoTicket  && countOfManualLottoTicket <= buyableLottoTicketCount) {
             return;
@@ -78,11 +78,11 @@ public class InputView {
         throw new IllegalArgumentException("유효한 수동 구매 개수가 아닙니다.");
     }
 
-    public static List<LottoTicket> inputManualLottoTickets(int count) {
+    public static List<LottoTicket> inputManualLottoTickets(long count) {
         return isManualTicketCountZero(count) ? new ArrayList<>() : createManualLottoTickets(count);
     }
 
-    private static List<LottoTicket> createManualLottoTickets(int count) {
+    private static List<LottoTicket> createManualLottoTickets(long count) {
         System.out.print(REQUEST_INPUT_MANUAL_LOTTO_NUMBERS);
         List<LottoTicket> tickets = new ArrayList<>();
         for (int i = 0; i< count; i++) {
@@ -92,7 +92,7 @@ public class InputView {
         return tickets;
     }
 
-    private static boolean isManualTicketCountZero(int count) {
+    private static boolean isManualTicketCountZero(long count) {
         return count == 0;
     }
 

--- a/src/main/java/view/input/InputView.java
+++ b/src/main/java/view/input/InputView.java
@@ -25,17 +25,18 @@ public class InputView {
     }
 
     public static WinningTicket inputWinningTicket() {
-        Set<LottoNumber> lottoNumbers = inputWinnnigNumbers();
+        LottoTicket winningLottoTicket = inputWinningLottoTicket();
         LottoNumber bonusNumber = inputBonusNumber();
 
-        return new WinningTicket(lottoNumbers, bonusNumber);
+        return new WinningTicket(winningLottoTicket, bonusNumber);
     }
 
-    private static Set<LottoNumber> inputWinnnigNumbers() {
+    private static LottoTicket inputWinningLottoTicket() {
         System.out.print(REQUEST_INPUT_WINNING_NUMBERS_MESSAGE);
         Set<LottoNumber> winningNumbers = inputLottoNumbers();
+        LottoTicket winningLottoTicket = LottoTicket.createManualTicket(winningNumbers);
         System.out.println();
-        return winningNumbers;
+        return winningLottoTicket;
     }
 
     private static Set<LottoNumber> inputLottoNumbers() {

--- a/src/main/java/view/output/OutputView.java
+++ b/src/main/java/view/output/OutputView.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 public class OutputView {
     public static void printLottoTickets(LottoTickets lottoTickets) {
         List<LottoTicket> tickets = lottoTickets.getLottoTickets();
-        System.out.printf("%d개를 구매했습니다.\n", tickets.size());
         System.out.println(makeLottoTicketsString(tickets));
         System.out.println();
     }
@@ -41,5 +40,11 @@ public class OutputView {
                     .sorted(Comparator.comparing(Rank::getReward))
                     .map(rank -> String.format("%s - %d개", rank, lottoGameResults.getRankCountOf(rank)))
                     .collect(Collectors.joining("\n"));
+    }
+
+    public static void printLottoTicketCounts(LottoTickets manualLottoTickets, LottoTickets randomLottoTickets) {
+        System.out.printf("수동으로 %d장, 자동으로 %d개를 구매했습니다.\n",
+                manualLottoTickets.getCountOfLottoTickets(),
+                randomLottoTickets.getCountOfLottoTickets());
     }
 }

--- a/src/main/java/view/output/OutputView.java
+++ b/src/main/java/view/output/OutputView.java
@@ -27,9 +27,9 @@ public class OutputView {
                     .collect(Collectors.joining("\n"));
     }
 
-    public static void printLottoTicketCounts(LottoTickets manualLottoTickets, LottoTickets randomLottoTickets) {
+    public static void printLottoTicketCounts(long countOfManualLottoTicket, long countOfRandomLottoTicket) {
         System.out.printf("수동으로 %d장, 자동으로 %d개를 구매했습니다.\n",
-                manualLottoTickets.getCountOfLottoTickets(),
-                randomLottoTickets.getCountOfLottoTickets());
+                countOfManualLottoTicket,
+                countOfRandomLottoTicket);
     }
 }

--- a/src/main/java/view/output/OutputView.java
+++ b/src/main/java/view/output/OutputView.java
@@ -4,27 +4,12 @@ import domain.lotto.*;
 
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.List;
 import java.util.stream.Collectors;
 
 public class OutputView {
     public static void printLottoTickets(LottoTickets lottoTickets) {
-        List<LottoTicket> tickets = lottoTickets.getLottoTickets();
-        System.out.println(makeLottoTicketsString(tickets));
+        System.out.println(lottoTickets);
         System.out.println();
-    }
-
-    private static String makeLottoTicketsString(List<LottoTicket> tickets) {
-        return tickets.stream()
-                .map(OutputView::makeLottoTicketString)
-                .collect(Collectors.joining("\n"));
-    }
-
-    private static String makeLottoTicketString(LottoTicket lottoTicket) {
-        return lottoTicket.getLottoNumbers().stream()
-                .mapToInt(LottoNumber::getNumber)
-                .mapToObj(String::valueOf)
-                .collect(Collectors.joining(", ", "[", "]"));
     }
 
     public static void printLottoGameResults(LottoGameResults lottoGameResults) {

--- a/src/test/java/domain/lotto/LottoGameResultsTest.java
+++ b/src/test/java/domain/lotto/LottoGameResultsTest.java
@@ -1,0 +1,89 @@
+package domain.lotto;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("LottoGameResults 클래스")
+class LottoGameResultsTest {
+
+    @Nested
+    @DisplayName("getReturnToInvestment 메서드는")
+    class Describe_getReturnToInvestment {
+
+        private WinningTicket winningTicket;
+
+        @BeforeEach
+        void setUpWinningTicket() {
+            Set<LottoNumber> winningNumbers = IntStream.rangeClosed(1,6).mapToObj(LottoNumber::of).collect(Collectors.toSet());
+            LottoNumber bonusNumber = LottoNumber.of(7);
+            this.winningTicket = new WinningTicket(winningNumbers, bonusNumber);
+        }
+
+        @Nested
+        @DisplayName("만약 1개의 로또를 구입하고 1등인 경우라면")
+        class Context_with_lottoTicket_is_First_rank {
+            @Test
+            @DisplayName("수익률 199999900.%를 리턴한다.")
+            void it_returns_199999900_returnToInvestment() {
+                Set<LottoNumber> lottoNumbers = IntStream.rangeClosed(1,6).mapToObj(LottoNumber::of).collect(Collectors.toSet());
+                LottoTickets lottoTickets = LottoTickets.createManualTickets(List.of(LottoTicket.createManualTicket(lottoNumbers)));
+                LottoGameResults sut = new LottoGameResults(lottoTickets, winningTicket);
+
+                double result = sut.getReturnToInvestment();
+
+                assertThat(result).isEqualTo(199999900.);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 1개의 로또를 구입하고 꽝인 경우라면")
+        class Context_with_lottoTicket_is_Failed_rank {
+            @Test
+            @DisplayName("수익률 -100%를 리턴한다.")
+            void it_returns_negative_100_returnToInvestment() {
+                Set<LottoNumber> lottoNumbers = IntStream.rangeClosed(7,12).mapToObj(LottoNumber::of).collect(Collectors.toSet());
+                LottoTickets lottoTickets = LottoTickets.createManualTickets(List.of(LottoTicket.createManualTicket(lottoNumbers)));
+                LottoGameResults sut = new LottoGameResults(lottoTickets, winningTicket);
+
+                double result = sut.getReturnToInvestment();
+
+                assertThat(result).isEqualTo(-100.);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 3개의 로또를 구입하고 5등이 1개인 경우라면")
+        class Context_with_Three_LottoTickets_buy_and_one_FIFTH_Rank {
+            @Test
+            @DisplayName("수익률 66.66666666666666% 리턴한다.")
+            void it_returns_66_returnToInvestment() {
+                Set<LottoNumber> lottoNumbers1 = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(7), LottoNumber.of(8), LottoNumber.of(9)).collect(Collectors.toSet());
+                Set<LottoNumber> lottoNumbers2 = IntStream.rangeClosed(7,12).mapToObj(LottoNumber::of).collect(Collectors.toSet());
+                Set<LottoNumber> lottoNumbers3 = IntStream.rangeClosed(7,12).mapToObj(LottoNumber::of).collect(Collectors.toSet());
+                LottoTicket manualTicket1 = LottoTicket.createManualTicket(lottoNumbers1);
+                LottoTicket manualTicket2 = LottoTicket.createManualTicket(lottoNumbers2);
+                LottoTicket manualTicket3 = LottoTicket.createManualTicket(lottoNumbers3);
+                LottoTickets lottoTickets = LottoTickets.createManualTickets(List.of(manualTicket1, manualTicket2, manualTicket3));
+                LottoGameResults sut = new LottoGameResults(lottoTickets, winningTicket);
+
+                double result = sut.getReturnToInvestment();
+
+                assertThat(result).isEqualTo(66.66666666666666);
+            }
+        }
+
+    }
+
+
+}

--- a/src/test/java/domain/lotto/LottoGameResultsTest.java
+++ b/src/test/java/domain/lotto/LottoGameResultsTest.java
@@ -25,8 +25,9 @@ class LottoGameResultsTest {
         @BeforeEach
         void setUpWinningTicket() {
             Set<LottoNumber> winningNumbers = IntStream.rangeClosed(1,6).mapToObj(LottoNumber::of).collect(Collectors.toSet());
+            LottoTicket winningLottoTicket = LottoTicket.createManualTicket(winningNumbers);
             LottoNumber bonusNumber = LottoNumber.of(7);
-            this.winningTicket = new WinningTicket(winningNumbers, bonusNumber);
+            this.winningTicket = new WinningTicket(winningLottoTicket, bonusNumber);
         }
 
         @Nested

--- a/src/test/java/domain/lotto/LottoNumberTest.java
+++ b/src/test/java/domain/lotto/LottoNumberTest.java
@@ -1,0 +1,52 @@
+package domain.lotto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("LottoNumber 클래스")
+class LottoNumberTest {
+
+    @Nested
+    @DisplayName("of 메서드는")
+    class Describe_of {
+        @Nested
+        @DisplayName("만약 1~45 사이의 정수가 주어진다면")
+        class Context_with_valid_parameter {
+            @Test
+            @DisplayName("해당 값에 해당하는 LottoNumber를 반환한다.")
+            void it_returns_a_LottoNumber() {
+                int number = 3;
+
+                LottoNumber lottoNumber = LottoNumber.of(number);
+
+                assertThat(lottoNumber.getNumber()).isEqualTo(number);
+            }
+        }
+
+        @Nested
+        @DisplayName("1보다 작은 정수가 주어진다면")
+        class Context_with_argument_is_less_than_1 {
+            @Test
+            @DisplayName("IllegalArgumentException 예외를 던진다.")
+            void it_throws_an_exception() {
+                int number = 0;
+                assertThatThrownBy(() -> LottoNumber.of(number)).isInstanceOf(IllegalArgumentException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("45보다 큰 정수가 주어진다면")
+        class Context_with_argument_is_greater_than_45 {
+            @Test
+            @DisplayName("IllegalArgumentException 예외를 던진다.")
+            void it_throws_an_exception() {
+                int number = 46;
+                assertThatThrownBy(() -> LottoNumber.of(number)).isInstanceOf(IllegalArgumentException.class);
+            }
+        }
+    }
+
+}

--- a/src/test/java/domain/lotto/LottoTicketTest.java
+++ b/src/test/java/domain/lotto/LottoTicketTest.java
@@ -1,15 +1,81 @@
 package domain.lotto;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class LottoTicketTest {
+@DisplayName("LottoTicket 클래스")
+class LottoTicketTest {
 
-    @Test
-    void createLotto() {
-        LottoTicket lottoTicket = LottoTicket.createRandomTicket();
+    @Nested
+    @DisplayName("createRandomTicket 메소드는")
+    class Describe_createRandomTicket {
 
-        assertThat(lottoTicket.getLottoNumbers().size()).isEqualTo(6);
+        @Nested
+        @DisplayName("만약 매개변수 없이 호출한다면")
+        class Context_without_parameter {
+            @Test
+            @DisplayName("6개의 랜덤 번호를 가진 로또 티켓(LottoTicket)을 리턴한다")
+            void it_return_a_Random_LottoTicket() {
+                LottoTicket lottoTicket = LottoTicket.createRandomTicket();
+
+                assertThat(lottoTicket.getLottoNumbers().size()).isEqualTo(6);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("createManualTicket 메소드는")
+    class Describe_createManualTicket {
+        @Nested
+        @DisplayName("만약 서로 다른 6개의 LottoNumbers가 주어진다면")
+        class Context_with_LottoNumbers {
+            @Test
+            @DisplayName("6개의 번호를 가진 로또 티켓(LottoTicket)을 리턴한다")
+            void it_return_a_Manual_LottoTicket() {
+                Set<LottoNumber> lottoNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(6))
+                        .collect(Collectors.toSet());
+
+                LottoTicket lottoTicket = LottoTicket.createManualTicket(lottoNumbers);
+
+                assertThat(lottoTicket.getLottoNumbers().size()).isEqualTo(6);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 6개보다 적은 LottoNumbers가 주어진다면")
+        class Context_with_LottoNumbers_Size_is_less_than_6 {
+            @Test
+            @DisplayName("IllegalArgumentException 예외를 던진다.")
+            void it_throw_a_exception() {
+                Set<LottoNumber> lottoNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(4), LottoNumber.of(5))
+                        .collect(Collectors.toSet());
+
+                assertThatThrownBy(() -> LottoTicket.createManualTicket(lottoNumbers)).isInstanceOf(IllegalArgumentException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 6개보다 많은 LottoNumbers가 주어진다면")
+        class Context_with_LottoNumbers_Size_is_greater_than_6 {
+            @Test
+            @DisplayName("IllegalArgumentException 예외를 던진다.")
+            void it_throw_a_exception() {
+                Set<LottoNumber> lottoNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(6), LottoNumber.of(7))
+                        .collect(Collectors.toSet());
+
+                assertThatThrownBy(() -> LottoTicket.createManualTicket(lottoNumbers)).isInstanceOf(IllegalArgumentException.class);
+            }
+        }
     }
 }

--- a/src/test/java/domain/lotto/LottoTicketTest.java
+++ b/src/test/java/domain/lotto/LottoTicketTest.java
@@ -46,7 +46,7 @@ class LottoTicketTest {
 
                 LottoTicket lottoTicket = LottoTicket.createManualTicket(lottoNumbers);
 
-                assertThat(lottoTicket.getLottoNumbers().size()).isEqualTo(6);
+                assertThat(lottoTicket.toString()).hasToString("[1, 2, 3, 4, 5, 6]");
             }
         }
 

--- a/src/test/java/domain/lotto/LottoTicketsTest.java
+++ b/src/test/java/domain/lotto/LottoTicketsTest.java
@@ -1,44 +1,120 @@
 package domain.lotto;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class LottoTicketsTest {
+@DisplayName("LottoTicketsTest 클래스")
+class LottoTicketsTest {
 
-    @Test
-    @DisplayName("6000원이 주어졌을 때 랜덤한 로또 티켓 6개를 생성한다.")
-    void createRandomLottoTicket() {
-        LottoTickets lottoTickets = LottoTickets.createRandomTickets(6);
+    @Nested
+    @DisplayName("createRandomLottoTicket 메서드는")
+    class Describe_createRandomLottoTicket {
+        @Nested
+        @DisplayName("만약 정수3이 주어전다면")
+        class Context_with_int_3 {
+            @Test
+            @DisplayName("3개의 랜덤한 LottoTicket을 가진 LottoTickets를 반환한다.")
+            void it_returns_LottoTickets_of_3_LottoTicket() {
+                int count = 6;
 
-        assertThat(lottoTickets.getLottoTickets().size()).isEqualTo(6);
+                LottoTickets sut = LottoTickets.createRandomTickets(count);
+
+                assertThat(sut.getLottoTickets().size()).isEqualTo(6);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 음수가 주어전다면")
+        class Context_with_int_negative {
+            @Test
+            @DisplayName("IllegalArgumentException 예외를 던진다.")
+            void it_throws_exception() {
+                int count = -1;
+
+                assertThatThrownBy(() -> LottoTickets.createRandomTickets(count))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+        }
     }
 
-    @Test
-    @DisplayName("수동 로또 티켓 리스트로 LottoTickets 생성")
-    void createManualLottoTicket() {
-        List<LottoTicket> tickets = new ArrayList<>();
-        tickets.add(LottoTicket.createRandomTicket());
-        tickets.add(LottoTicket.createRandomTicket());
-        tickets.add(LottoTicket.createRandomTicket());
+    @Nested
+    @DisplayName("createManualLottoTicket 메서드는")
+    class Describe_createManualLottoTicket {
+        @Nested
+        @DisplayName("만약 정상적인 List<LottoTicket> 형태의 로또 티켓 두개를 넣는다면")
+        class Context_with_normal_manual_lottotickets {
+            private List<LottoTicket> initLottoTickets() {
+                Set<LottoNumber> lottoNumbers1 = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(6))
+                        .collect(Collectors.toSet());
 
-        LottoTickets manualLottoTickets = LottoTickets.createManualTickets(tickets);
+                Set<LottoNumber> lottoNumbers2 = Stream.of(LottoNumber.of(11), LottoNumber.of(12), LottoNumber.of(13),
+                                LottoNumber.of(14), LottoNumber.of(15), LottoNumber.of(16))
+                        .collect(Collectors.toSet());
 
-        assertThat(manualLottoTickets.getLottoTickets().size()).isEqualTo(3);
+                List<LottoTicket> tickets = new ArrayList<>();
+                tickets.add(LottoTicket.createManualTicket(lottoNumbers1));
+                tickets.add(LottoTicket.createManualTicket(lottoNumbers2));
+                return tickets;
+            }
+
+            @Test
+            @DisplayName("지정한 2개의 LottoTicket을 가진 LottoTickets를 반환한다.")
+            void it_returns_normal_lottoticket() {
+                List<LottoTicket> tickets = initLottoTickets();
+
+                LottoTickets sut = LottoTickets.createManualTickets(tickets);
+
+                assertThat(sut.toString()).hasToString("[1, 2, 3, 4, 5, 6]\n[11, 12, 13, 14, 15, 16]");
+            }
+        }
+
     }
 
-    @Test
-    @DisplayName("수동+자동 티켓 합쳐 LottoTickets 생성")
-    void mergeLottoTicket() {
-        LottoTickets lottoTickets1 = LottoTickets.createRandomTickets(5);
-        LottoTickets lottoTickets2 = LottoTickets.createRandomTickets(5);
+    @Nested
+    @DisplayName("merge 메서드는")
+    class Describe_merge {
+        @Nested
+        @DisplayName("만약 2개의 로또 티켓을 가지고 있는 LottoTickets를 2개 넣는다면")
+        class Context_with_merge_lottotickets {
+            private LottoTickets initLottoTickets() {
+                Set<LottoNumber> lottoNumbers1 = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(6))
+                        .collect(Collectors.toSet());
 
-        LottoTickets mergeLottoTickets = LottoTickets.merge(lottoTickets1, lottoTickets2);
+                Set<LottoNumber> lottoNumbers2 = Stream.of(LottoNumber.of(11), LottoNumber.of(12), LottoNumber.of(13),
+                                LottoNumber.of(14), LottoNumber.of(15), LottoNumber.of(16))
+                        .collect(Collectors.toSet());
 
-        assertThat(mergeLottoTickets.getLottoTickets().size()).isEqualTo(10);
+                List<LottoTicket> tickets = new ArrayList<>();
+                tickets.add(LottoTicket.createManualTicket(lottoNumbers1));
+                tickets.add(LottoTicket.createManualTicket(lottoNumbers2));
+
+                return LottoTickets.createManualTickets(tickets);
+            }
+
+            @Test
+            @DisplayName("합쳐진 4개의 LottoTicket을 가진 LottoTickets를 반환한다.")
+            void it_returns_normal_lottoticket() {
+                LottoTickets tickets = initLottoTickets();
+                LottoTickets tickets2 = initLottoTickets();
+
+                LottoTickets sut = LottoTickets.merge(tickets, tickets2);
+
+                assertThat(sut.toString()).hasToString("[1, 2, 3, 4, 5, 6]\n[11, 12, 13, 14, 15, 16]\n" +
+                        "[1, 2, 3, 4, 5, 6]\n[11, 12, 13, 14, 15, 16]");
+            }
+        }
     }
+
 }

--- a/src/test/java/domain/lotto/LottoTicketsTest.java
+++ b/src/test/java/domain/lotto/LottoTicketsTest.java
@@ -3,6 +3,9 @@ package domain.lotto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LottoTicketsTest {
@@ -10,9 +13,32 @@ public class LottoTicketsTest {
     @Test
     @DisplayName("6000원이 주어졌을 때 랜덤한 로또 티켓 6개를 생성한다.")
     void createRandomLottoTicket() {
-        LottoTickets lottoTickets = LottoTickets.createRandomTickets(new Money(6000));
+        LottoTickets lottoTickets = LottoTickets.createRandomTickets(6);
 
         assertThat(lottoTickets.getLottoTickets().size()).isEqualTo(6);
     }
 
+    @Test
+    @DisplayName("수동 로또 티켓 리스트로 LottoTickets 생성")
+    void createManualLottoTicket() {
+        List<LottoTicket> tickets = new ArrayList<>();
+        tickets.add(LottoTicket.createRandomTicket());
+        tickets.add(LottoTicket.createRandomTicket());
+        tickets.add(LottoTicket.createRandomTicket());
+
+        LottoTickets manualLottoTickets = LottoTickets.createManualTickets(tickets);
+
+        assertThat(manualLottoTickets.getLottoTickets().size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("수동+자동 티켓 합쳐 LottoTickets 생성")
+    void mergeLottoTicket() {
+        LottoTickets lottoTickets1 = LottoTickets.createRandomTickets(5);
+        LottoTickets lottoTickets2 = LottoTickets.createRandomTickets(5);
+
+        LottoTickets mergeLottoTickets = LottoTickets.merge(lottoTickets1, lottoTickets2);
+
+        assertThat(mergeLottoTickets.getLottoTickets().size()).isEqualTo(10);
+    }
 }

--- a/src/test/java/domain/lotto/MoneyTest.java
+++ b/src/test/java/domain/lotto/MoneyTest.java
@@ -1,32 +1,54 @@
 package domain.lotto;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@DisplayName("Money 클래스")
 class MoneyTest {
 
-    @Test
-    @DisplayName("정상인경우")
-    void createMoney() {
-        Money money = new Money(1000);
+    @Nested
+    @DisplayName("생성자는")
+    class Describe_constructor {
+        @Nested
+        @DisplayName("만약 구입금이 1000 이상의 1000의 배수일 경우")
+        class Context_with_Multiple_of_1000 {
+            @Test
+            @DisplayName("구입금에 대응하는 Money 객체를 반환한다.")
+            void it_returns_money_instance() {
+                long purchaseAmount = 1000;
+                Money money = new Money(purchaseAmount);
 
-        assertThat(money.getPurchaseAmount()).isEqualTo(1000L);
-    }
+                long innerPurchaseAmount = money.getPurchaseAmount();
+                assertThat(innerPurchaseAmount).isEqualTo(purchaseAmount);
+            }
+        }
 
-    @Test
-    @DisplayName("음수일 때 Money 생성 시 예외 발생")
-    void purchaseAmountLessThanPriceOfLotto() {
-        assertThatThrownBy(() -> new Money(-1))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
+        @Nested
+        @DisplayName("만약 구입금이 경계값(1000)보다 작은 액수일 경우")
+        class Context_with_less_than_1000 {
+            @Test
+            @DisplayName("IllegalArgumentException을 throw한다.")
+            void it_returns_money_instance() {
+                long purchaseAmount = 999;
+                assertThatThrownBy(() -> new Money(purchaseAmount))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+        }
 
-    @Test
-    @DisplayName("1000의 배수가 아닐 때 Money 생성 시 예외 발생")
-    void multipleOfPrice() {
-        assertThatThrownBy(() -> new Money(1001))
-                .isInstanceOf(IllegalArgumentException.class);
+        @Nested
+        @DisplayName("만약 구입금이 경계값(1000)보다 크고, 1000의 배수가 아닐 경우")
+        class Context_with_greater_than_1000_and_not_multiple_of_1000 {
+            @Test
+            @DisplayName("IllegalArgumentException을 throw한다.")
+            void it_returns_money_instance() {
+                long purchaseAmount = 1001;
+                assertThatThrownBy(() -> new Money(purchaseAmount))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+        }
     }
 }

--- a/src/test/java/domain/lotto/WinningTicketTest.java
+++ b/src/test/java/domain/lotto/WinningTicketTest.java
@@ -1,7 +1,6 @@
 package domain.lotto;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -9,18 +8,188 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.*;
 
-
+@DisplayName("WinningTicket 클래스")
 class WinningTicketTest {
 
-    @Test
-    @DisplayName("당첨 번호와 보너스 번호가 겹칠 때 WinningTicket 생성 시 예외 발생")
-    void createWinningTicket() {
-        Set<LottoNumber> winningNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
-                                                    LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(6))
-                                                .collect(Collectors.toSet());
+    @Nested
+    @DisplayName("생성자는")
+    class Describe_constructor {
 
-        LottoNumber bonusNumber = LottoNumber.of(6);
-        assertThatThrownBy(() -> new WinningTicket(winningNumbers, bonusNumber)).isInstanceOf(IllegalArgumentException.class);
+        @Nested
+        @DisplayName("만약 당첨번호와 보너스번호가 겹친다면")
+        class Context_with_Duplicate_WinningNumbers_and_BonusNumber {
+
+            Set<LottoNumber> winningNumbers;
+
+            @BeforeEach
+            void setUpWinningNumber() {
+                this.winningNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(6))
+                        .collect(Collectors.toSet());
+            }
+
+            @Test
+            @DisplayName("IllegalArgumentException을 던진다.")
+            void it_throws_exception() {
+                LottoNumber bonusNumber = LottoNumber.of(6);
+                assertThatThrownBy(() -> new WinningTicket(winningNumbers, bonusNumber))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
+        }
+
+    }
+
+    @Nested
+    @DisplayName("match 메서드는")
+    class Describe_match {
+
+        private WinningTicket winningTicket;
+
+        @BeforeEach
+        void setUpWinningNumber() {
+            Set<LottoNumber> winningNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                            LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(6))
+                    .collect(Collectors.toSet());
+            LottoNumber bonusNumber = LottoNumber.of(7);
+            winningTicket = new WinningTicket(winningNumbers, bonusNumber);
+        }
+
+        @Nested
+        @DisplayName("만약 로또티켓의 6개의 번호가 일치하면")
+        class Context_with_Six_Number_Match {
+
+            @Test
+            @DisplayName("1등 Rank를 반환한다.")
+            void it_returns_First_Rank() {
+                Set<LottoNumber> lottoNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(6))
+                        .collect(Collectors.toSet());
+
+                LottoTicket lottoTicket = LottoTicket.createManualTicket(lottoNumbers);
+                Rank matchRank = winningTicket.match(lottoTicket);
+                assertThat(matchRank).isSameAs(Rank.FIRST);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 로또티켓의 5개의 번호가 일치하고, 보너스넘버도 일치하면")
+        class Context_with_Five_Number_Match_and_Match_Bonus {
+
+            @Test
+            @DisplayName("2등 Rank를 반환한다.")
+            void it_returns_Second_Rank() {
+                Set<LottoNumber> lottoNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(7))
+                        .collect(Collectors.toSet());
+
+                LottoTicket lottoTicket = LottoTicket.createManualTicket(lottoNumbers);
+                Rank matchRank = winningTicket.match(lottoTicket);
+                assertThat(matchRank).isSameAs(Rank.SECOND);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 로또티켓의 5개의 번호가 일치하고, 보너스넘버가 일치하지 않으면")
+        class Context_with_Five_Number_Match_and_No_Match_Bonus {
+
+            @Test
+            @DisplayName("3등 Rank를 반환한다.")
+            void it_returns_Third_Rank() {
+                Set<LottoNumber> lottoNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(8))
+                        .collect(Collectors.toSet());
+
+                LottoTicket lottoTicket = LottoTicket.createManualTicket(lottoNumbers);
+                Rank matchRank = winningTicket.match(lottoTicket);
+                assertThat(matchRank).isSameAs(Rank.THIRD);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 로또티켓의 4개의 번호가 일치한다면")
+        class Context_with_Four_Number_Match {
+
+            @Test
+            @DisplayName("4등 Rank를 반환한다.")
+            void it_returns_Fourth_Rank() {
+                Set<LottoNumber> lottoNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(4), LottoNumber.of(8), LottoNumber.of(9))
+                        .collect(Collectors.toSet());
+
+                LottoTicket lottoTicket = LottoTicket.createManualTicket(lottoNumbers);
+                Rank matchRank = winningTicket.match(lottoTicket);
+                assertThat(matchRank).isSameAs(Rank.FOURTH);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 로또티켓의 3개의 번호가 일치한다면")
+        class Context_with_Three_Number_Match {
+
+            @Test
+            @DisplayName("5등 Rank를 반환한다.")
+            void it_returns_Fifth_Rank() {
+                Set<LottoNumber> lottoNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
+                                LottoNumber.of(8), LottoNumber.of(9), LottoNumber.of(10))
+                        .collect(Collectors.toSet());
+
+                LottoTicket lottoTicket = LottoTicket.createManualTicket(lottoNumbers);
+                Rank matchRank = winningTicket.match(lottoTicket);
+                assertThat(matchRank).isSameAs(Rank.FIFTH);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 로또티켓의 2개의 번호가 일치한다면")
+        class Context_with_Two_Number_Match {
+
+            @Test
+            @DisplayName("Failed Rank를 반환한다.")
+            void it_returns_Failed_Rank() {
+                Set<LottoNumber> lottoNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(8),
+                                LottoNumber.of(9), LottoNumber.of(10), LottoNumber.of(11))
+                        .collect(Collectors.toSet());
+
+                LottoTicket lottoTicket = LottoTicket.createManualTicket(lottoNumbers);
+                Rank matchRank = winningTicket.match(lottoTicket);
+                assertThat(matchRank).isSameAs(Rank.FAILED);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 로또티켓의 1개의 번호가 일치한다면")
+        class Context_with_One_Number_Match {
+
+            @Test
+            @DisplayName("Failed Rank를 반환한다.")
+            void it_returns_Failed_Rank() {
+                Set<LottoNumber> lottoNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(8), LottoNumber.of(9),
+                                LottoNumber.of(10), LottoNumber.of(11), LottoNumber.of(12))
+                        .collect(Collectors.toSet());
+
+                LottoTicket lottoTicket = LottoTicket.createManualTicket(lottoNumbers);
+                Rank matchRank = winningTicket.match(lottoTicket);
+                assertThat(matchRank).isSameAs(Rank.FAILED);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 로또티켓의 0개의 번호가 일치한다면")
+        class Context_with_No_Number_Match {
+
+            @Test
+            @DisplayName("Failed Rank를 반환한다.")
+            void it_returns_Failed_Rank() {
+                Set<LottoNumber> lottoNumbers = Stream.of(LottoNumber.of(8), LottoNumber.of(9), LottoNumber.of(10),
+                                LottoNumber.of(11), LottoNumber.of(12), LottoNumber.of(13))
+                        .collect(Collectors.toSet());
+
+                LottoTicket lottoTicket = LottoTicket.createManualTicket(lottoNumbers);
+                Rank matchRank = winningTicket.match(lottoTicket);
+                assertThat(matchRank).isSameAs(Rank.FAILED);
+            }
+        }
+
     }
 
 }

--- a/src/test/java/domain/lotto/WinningTicketTest.java
+++ b/src/test/java/domain/lotto/WinningTicketTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.*;
 
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.*;
@@ -19,20 +20,18 @@ class WinningTicketTest {
         @DisplayName("만약 당첨번호와 보너스번호가 겹친다면")
         class Context_with_Duplicate_WinningNumbers_and_BonusNumber {
 
-            Set<LottoNumber> winningNumbers;
+            LottoTicket winningLottoTicket;
 
             @BeforeEach
             void setUpWinningNumber() {
-                this.winningNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
-                                LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(6))
-                        .collect(Collectors.toSet());
+                this.winningLottoTicket = LottoTicket.createManualTicket(IntStream.rangeClosed(1, 6).mapToObj(LottoNumber::of).collect(Collectors.toSet()));
             }
 
             @Test
             @DisplayName("IllegalArgumentException을 던진다.")
             void it_throws_exception() {
                 LottoNumber bonusNumber = LottoNumber.of(6);
-                assertThatThrownBy(() -> new WinningTicket(winningNumbers, bonusNumber))
+                assertThatThrownBy(() -> new WinningTicket(winningLottoTicket, bonusNumber))
                         .isInstanceOf(IllegalArgumentException.class);
             }
         }
@@ -50,8 +49,9 @@ class WinningTicketTest {
             Set<LottoNumber> winningNumbers = Stream.of(LottoNumber.of(1), LottoNumber.of(2), LottoNumber.of(3),
                             LottoNumber.of(4), LottoNumber.of(5), LottoNumber.of(6))
                     .collect(Collectors.toSet());
+            LottoTicket winningLottoTicket = LottoTicket.createManualTicket(winningNumbers);
             LottoNumber bonusNumber = LottoNumber.of(7);
-            winningTicket = new WinningTicket(winningNumbers, bonusNumber);
+            winningTicket = new WinningTicket(winningLottoTicket, bonusNumber);
         }
 
         @Nested


### PR DESCRIPTION
### 🔢 로또 3단계 - 수동구매 기능 추가

안녕하세요! @ku-kim  @ttasjwi입니다. 1주일 동안 페어 프로그래밍을 하며 토론하고 지식을 공유하며 함께 성장할 수 있었습니다.   
3단계 미션 완료하여 리뷰 요청 드립니다. 피드백 매번 감사합니다. 🙇‍♂️

### 미션 요구사항 및 3단계 변경 내역
- [x] 사용자 입력을 통해 수동 추첨번호를 입력할 수 있도록 기능 추가
    - detail : 구입금액, 수동으로 생성하는 티켓 수, 수동 티켓들에 대한 입력 기능 요구
- [x] 예외가 발생하는 부분에 대해 Exception을 발생시키고, 적절한 예외처리
- [x] 상속과 인터페이스, 조합을 이용해 구현을 간결화하기
- 자세한 변경 내역은 [README.md](https://github.com/codesquad-members-2022/java-lotto/pull/51/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)에 정리했습니다.

### 이전 #13 #25 피드백 적용
- [x] WinningTicket와 LottoTicket의 공통점을 발견하여 WinningTicket 생성할 LottoTicket을 주입하여 생성
- [x] Rank enum 리팩토링 : 5등 이외의 순위를 나타내는 FAILD 값이 -1로 되어있던 것을 0으로 변경
- [x] LottoGameResults.getTotalReward() 메서드 가독성을 위한 stream 으로 재변경 
- [ ] 랜덤 로또 생성 시 셋 반복이 아닌 리스트 셔플로 가져오기

### 미션 결과

<details>
<summary> 🖼 결과 : 정상 입력 </summary>
<div markdown="1">

![정상 입력](https://i.imgur.com/2PCnFUV.jpg)

</div>
</details>

<details>
<summary> 🖼 결과 : 예외 입력 </summary>
<div markdown="1">

![예외 입력 시 재입력](https://i.imgur.com/iwNjJid.jpg)

</div>
</details>

<details>
<summary> 🖼 결과 :  테스트 </summary>
<div markdown="1">

![테스트1](https://i.imgur.com/XFEm0X2.jpg)

![테스트2](https://i.imgur.com/sXjGiih.jpg)
</div>
</details>

### 질문
- Q) 사용자 입력이 유효하지 않은 경우 예외 처리(재입력 받기 위한 로직) 위치는 어디가 적절할까요?
    - 현재 컨트롤러에서 기능 단위로 묶어 한 번에 처리하고 있습니다.(try-catch + 재귀로 입력 메서드 재실행)
    - 왜냐하면 입력받는 경우가 많아 모든 입력마다 예외처리한다면 InputView가 복잡해질 거 같았습니다.

---

감사합니다. 🙂